### PR TITLE
test/1

### DIFF
--- a/fullstack/db/schema.sql
+++ b/fullstack/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
 );
 
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL

--- a/fullstack/docker-compose.yml
+++ b/fullstack/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - 3305:3305
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       timeout: 1s
       retries: 5
 
@@ -49,4 +49,3 @@ services:
 volumes:
   control-posts-node-modules:
   main:
-      


### PR DESCRIPTION
Causa do problema: 
Tipo de dado da coluna 'id' da tabela users, no arquivo schema.sql.

Razão da alteração:
Corrigir a definição da coluna 'id' na tabela 'users'.
A coluna 'id' estava utilizando o tipo de dado VARCHAR(100) que não é apropriado para uma chave primária com AUTO_INCREMENT.

Como soluciona o problema:
A alteração remove a declaração incorreta da coluna 'id' e substitui por uma declaração correta usando 'INT' como tipo de dado.
