### PR TITLE
test/2

### DIFF
--- a/fullstack/package.json
+++ b/fullstack/package.json
@@ -21,7 +21,9 @@
     "jest": "^28.1.0",
     "nodemon": "^2.0.16"
   },
-  "scripts": {},
+  "scripts": {
+    "start": "node ."
+  },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
Causa do problema:
Ausência do script "start" no package.json

Razão da alteração:
Adicionar um script "start" na seção "scripts" do package.json.

Como soluciona o problema:
Permite que se inicie o aplicativo utilizando o comando 'npm start' ao subir o compose.