### PR TITLE
test/3

### DIFF
--- a/fullstack/src/app.js
+++ b/fullstack/src/app.js
@@ -15,7 +15,7 @@ const whitelist = [
 
 app.use(cors({
   origin: function (origin, callback) {
-    const allowed = whitelist.indexOf(origin) !== -1
+    const allowed = whitelist.indexOf(origin) !== -1 || !origin
     if (allowed) return callback(null, true);
 
     callback(new Error('Not allowed by CORS'))


### PR DESCRIPTION
Causa do problema:
Carregar a página na mesma origem que faz as chamadas de API.

Razão da alteração:
Fazer com que o cors aceite requisições de mesma origem.

Como Soluciona o Problema:
A modificação permite que o middleware cors aceite solicitações com origens undefined. 