### PR TITLE
test/8

### DIFF
--- a/fullstack/db/schema.sql
+++ b/fullstack/db/schema.sql
@@ -1,16 +1,17 @@
 USE `main`;
 
-CREATE TABLE posts (
-    id INT PRIMARY KEY AUTO_INCREMENT,
-    author_id INT NOT NULL,
-    post_text VARCHAR(200)
-);
-
 CREATE TABLE users (
     id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE posts (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    author_id INT NOT NULL,
+    post_text VARCHAR(200),
+    FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
 ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';


### PR DESCRIPTION
Arquivo schema.sql

Causa do problema:
A tabela posts estava sendo criada com a coluna author_id sem ser uma foreign key.

Razão da alteração:
Para que ao criar as tabelas a coluna author_id da coluna posts seja referenciada ao usuário que a criou.

Como soluciona o problema:
Adicionando "FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE" ao final da criação da tabela posts.