### PR TITLE
test/10

### DIFF
--- a/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -13,14 +13,13 @@ const createPostRepositories = async ({
     try {
         const post_created = await transaction('posts').insert(post)
         
-        const has_response = !Array.isArray(post_created) && post_created.length > 0;
+        const has_response = Array.isArray(post_created) && post_created.length > 0;
 
         if (!has_response) {
             return {
                 post_created: []
             }
         }
-
 
         return {
             post_created


### PR DESCRIPTION
POST /post

Causa do problema:
No arquivo src/modules/repositories/Post/createPostRepositories/createPostRepositories.js a constante "has_response" estava verificando se "post_created" não era um array fazendo com que sempre caísse no if.

Razão da alteração:
Para que a verificação seja feita corretamente se o post é criado ou não.

Como soluciona o problema:
Apenas removendo o "!" na frente do Array, fazendo assim com que seja verificado corretamente se o post foi criado ou não.