### PR TITLE
test/11

### DIFF
--- a/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -21,6 +21,8 @@ const createPostRepositories = async ({
             }
         }
 
+        await commitTransaction({transaction})
+
         return {
             post_created
         }


### PR DESCRIPTION
POST /post

Causa do problema:
Quando um novo post é criado ele não estava sendo salvo no banco de dados.

Razão da alteração:
Para que ao criar um novo post ele seja salvo no banco de dados.

Como soluciona o problema:
No arquivo src/modules/repositories/Post/createPostRepositories/createPostRepositories.js adiciona-se o commit da transaction para que seja salvo o novo post no banco de dados.