### PR TITLE
test/13

### DIFF
--- a/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -4,13 +4,13 @@ const {
     rollbackTransaction
 } = require('../../../common/handlers')
 
-const deletePostRepositories = async (
+const deletePostRepositories = async ({
     post_id
-) => {
+}) => {
     const { transaction } = await getTransaction();
 
     try {
-        await transaction('posts').del()
+        await transaction('posts').where({ id: post_id }).del();
 
         await commitTransaction({transaction})
         


### PR DESCRIPTION
DELETE /post

Causa do problema:
No arquivo src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js estava faltando a condição do where na transaction, fazendo com que todos os posts fossem deletados.

Razão da alteração:
Para que seja feito o delete apenas do post passado como parâmetro.

Como soluciona o problema:
Colocando a condição where na transaction.